### PR TITLE
fix phpseclib version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "monolog/monolog": "~1.6",
         "nesbot/carbon": "~1.0",
         "patchwork/utf8": "~1.1",
-        "phpseclib/phpseclib": "0.3.*",
+        "phpseclib/phpseclib": "1.*",
         "predis/predis": "0.8.*",
         "stack/builder": "~1.0",
         "swiftmailer/swiftmailer": "~5.1",


### PR DESCRIPTION
phpseclib 0.3 is very old and not compatible with php 7 (`Methods with the same name as their class will not be constructors in a future version of PHP; Net_SFTP has a deprecated constructor`)
as far as I can see, the 1.x branch is compatible with the 0.3 api